### PR TITLE
support batch_size sequence_length as args

### DIFF
--- a/macro_benchmark/DIEN/script/constants.py
+++ b/macro_benchmark/DIEN/script/constants.py
@@ -1,4 +1,0 @@
-BS = 1
-MAX_ITERS = 10
-NS = 5
-SL = 10

--- a/macro_benchmark/DIEN/script/rnn.py
+++ b/macro_benchmark/DIEN/script/rnn.py
@@ -41,8 +41,6 @@ from tensorflow.python.util import nest
 from tensorflow.python.ipu.ops.embedding_ops import embedding_lookup as ipu_embedding_lookup
 
 import tensorflow as tf
-from constants import BS
-from constants import MAX_ITERS
 
 # pylint: disable=protected-access
 _concat = rnn_cell_impl._concat
@@ -438,7 +436,7 @@ def bidirectional_dynamic_rnn(cell_fw, cell_bw, inputs, sequence_length=None,
   return (outputs, output_states)
 
 
-def dynamic_rnn(cell, inputs, att_scores=None, sequence_length=None, initial_state=None,
+def dynamic_rnn(cell, inputs, max_iteration, att_scores=None, sequence_length=None, initial_state=None,
                 dtype=None, parallel_iterations=None, swap_memory=False,
                 time_major=False, scope=None):
   """Creates a recurrent neural network specified by RNNCell `cell`.
@@ -611,6 +609,7 @@ def dynamic_rnn(cell, inputs, att_scores=None, sequence_length=None, initial_sta
         state,
         parallel_iterations=parallel_iterations,
         swap_memory=swap_memory,
+        max_iteration = max_iteration,
         att_scores = att_scores,
         sequence_length=sequence_length,
         dtype=dtype)
@@ -630,6 +629,7 @@ def _dynamic_rnn_loop(cell,
                       initial_state,
                       parallel_iterations,
                       swap_memory,
+                      max_iteration,
                       att_scores = None,
                       sequence_length=None,
                       dtype=None):
@@ -786,7 +786,7 @@ def _dynamic_rnn_loop(cell,
           loop_vars=(time, output_ta, state, att_scores),
           parallel_iterations=parallel_iterations,
           swap_memory=swap_memory,
-          maximum_iterations=MAX_ITERS,
+          maximum_iterations=max_iteration,
           )
   else:
       _, output_final_ta, final_state = control_flow_ops.while_loop(
@@ -795,7 +795,7 @@ def _dynamic_rnn_loop(cell,
           loop_vars=(time, output_ta, state),
           parallel_iterations=parallel_iterations,
           swap_memory=swap_memory,
-          maximum_iterations=MAX_ITERS,
+          maximum_iterations=max_iteration,
           )
 
   # Unpack final output if not using output tuples.

--- a/macro_benchmark/DIEN/script/utils.py
+++ b/macro_benchmark/DIEN/script/utils.py
@@ -8,8 +8,6 @@ from tensorflow.python.ops import array_ops
 from tensorflow.python.ops import variable_scope as vs
 from keras import backend as K
 
-from constants import MAX_ITERS
-
 _BIAS_VARIABLE_NAME = "bias"
 _WEIGHTS_VARIABLE_NAME = "kernel"
 
@@ -426,7 +424,7 @@ def self_attention(facts, ATTENTION_SIZE, mask, stag='null'):
                                size=0,
                                dynamic_size=True,
                                element_shape=(facts[:, 0, :].get_shape()))
-    _, output_op, _ = tf.while_loop(cond, body, [facts, output_ta, 0], maximum_iterations=MAX_ITERS)
+    _, output_op, _ = tf.while_loop(cond, body, [facts, output_ta, 0])
     self_attention = output_op.stack()
     self_attention = tf.transpose(self_attention, perm = [1, 0, 2])
     return self_attention
@@ -450,7 +448,7 @@ def self_all_attention(facts, ATTENTION_SIZE, mask, stag='null'):
                                size=0,
                                dynamic_size=True,
                                element_shape=(facts[:, 0, :].get_shape()))
-    _, output_op, _ = tf.while_loop(cond, body, [facts, output_ta, 0], maximum_iterations=MAX_ITERS)
+    _, output_op, _ = tf.while_loop(cond, body, [facts, output_ta, 0])
     self_attention = output_op.stack()
     self_attention = tf.transpose(self_attention, perm = [1, 0, 2])
     return self_attention


### PR DESCRIPTION
1) remove constants.py which contains bs,seq_len,negative samples
2) pass bs,seq_len and # of negative samples as options when generate model
3) revert script/utils.py as self_attention/self_all_attention function not used in current models

TODO:
1) DIEN cannot be executed for BS > 1
2)Model_DIN_V2_Gru_Gru_att/Model_DIN_V2_Gru_QA_attGru/Model_DIN_V2_Gru_Vec_attGru cann't be launched

Signed-off-by: chengshun.xia <chengshunx@graphcore.ai>